### PR TITLE
 Firebaseのパスワードリセットを実装しました。

### DIFF
--- a/lib/screen/login/login_screen.dart
+++ b/lib/screen/login/login_screen.dart
@@ -98,6 +98,13 @@ class LoginScreen extends HookConsumerWidget {
                     title: '新規登録はこちら',
                     color: Colors.lightBlue,
                   ),
+                  AppTextButton(
+                    onPressed: () => ref
+                        .read(loginScreenViewModelProvider.notifier)
+                        .passwordResetScreen(context),
+                    title: 'パスワードを忘れた場合',
+                    color: Colors.lightBlue,
+                  ),
                 ],
               ),
             ),

--- a/lib/screen/login/login_screen_view_model.dart
+++ b/lib/screen/login/login_screen_view_model.dart
@@ -114,4 +114,8 @@ class LoginScreenViewModel extends ChangeNotifier {
   void createAccountScreen(BuildContext context) {
     NavigationUtils.createAccountScreen(context);
   }
+
+  void passwordResetScreen(BuildContext context) {
+    NavigationUtils.passwordResetScreen(context);
+  }
 }

--- a/lib/screen/login/password_reset_screen.dart
+++ b/lib/screen/login/password_reset_screen.dart
@@ -1,0 +1,86 @@
+import 'package:disney_app/core/component/app_elevated_button.dart';
+import 'package:disney_app/core/component/app_text_field.dart';
+import 'package:disney_app/core/theme/app_color_style.dart';
+import 'package:disney_app/gen/assets.gen.dart';
+import 'package:disney_app/provider/loading_provider.dart';
+import 'package:disney_app/screen/login/password_reset_screen_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:loading_animation_widget/loading_animation_widget.dart';
+
+class PasswordResetScreen extends ConsumerWidget {
+  const PasswordResetScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(passwordResetScreenViewModelProvider);
+    final loading = ref.watch(loadingProvider);
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: AppColorStyle.appColor,
+        elevation: 0,
+      ),
+      body: Center(
+        child: Stack(
+          children: [
+            Column(
+              children: [
+                const Spacer(),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Image.asset(
+                      Assets.images.empty.path,
+                      width: 40,
+                      height: 40,
+                    ),
+                    const SizedBox(width: 10),
+                    const Text(
+                      'パスワードの再設定',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 23,
+                        color: AppColorStyle.appColor,
+                      ),
+                    ),
+                  ],
+                ),
+                const Spacer(),
+                AppTextField(
+                  controller: state.emailController,
+                  hintText: 'メールアドレス',
+                  maxLines: 1,
+                ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 20),
+                  child: Text(
+                    'メールアドレスにパスワード再設定のメールを送信します。',
+                    style: TextStyle(
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                AppElevatedButton(
+                  onPressed: () => ref
+                      .read(passwordResetScreenViewModelProvider)
+                      .sendEmail(context),
+                  title: 'メールを送る',
+                ),
+                const Spacer(),
+              ],
+            ),
+            loading
+                ? Center(
+                    child: LoadingAnimationWidget.dotsTriangle(
+                      color: AppColorStyle.appColor,
+                      size: 50,
+                    ),
+                  )
+                : const SizedBox(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screen/login/password_reset_screen_view_model.dart
+++ b/lib/screen/login/password_reset_screen_view_model.dart
@@ -1,0 +1,49 @@
+import 'package:disney_app/provider/loading_provider.dart';
+import 'package:disney_app/utils/authentication.dart';
+import 'package:disney_app/utils/function_utils.dart';
+import 'package:disney_app/utils/snack_bar_utils.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+final passwordResetScreenViewModelProvider =
+    ChangeNotifierProvider.autoDispose<PasswordResetScreenViewModel>(
+  (ref) {
+    return PasswordResetScreenViewModel(ref);
+  },
+);
+
+class PasswordResetScreenViewModel extends ChangeNotifier {
+  PasswordResetScreenViewModel(this.ref);
+
+  final storage = const FlutterSecureStorage();
+  final TextEditingController emailController = TextEditingController();
+  AutoDisposeChangeNotifierProviderRef<PasswordResetScreenViewModel> ref;
+
+  Loading get loading => ref.read(loadingProvider.notifier);
+
+  Future<void> sendEmail(BuildContext context) async {
+    if (emailController.text.isNotEmpty) {
+      loading.isLoading = true;
+      try {
+        await Authentication.resetPassword(emailController.text);
+        await Future<void>.delayed(Duration.zero).then((_) {
+          SnackBarUtils.snackBar(context, 'メールを送信しました。');
+        });
+        await Future<void>.delayed(const Duration(seconds: 2)).then((_) {
+          loading.isLoading = false;
+          Navigator.pop(context);
+        });
+      } on FirebaseAuthException catch (e) {
+        loading.isLoading = false;
+        final errorMessage = FunctionUtils().checkLoginError(e.toString());
+        SnackBarUtils.snackBar(context, errorMessage);
+      }
+    } else {
+      await Future<void>.delayed(Duration.zero).then((_) {
+        SnackBarUtils.snackBar(context, 'メールアドレスを入力してください');
+      });
+    }
+  }
+}

--- a/lib/utils/authentication.dart
+++ b/lib/utils/authentication.dart
@@ -52,4 +52,8 @@ class Authentication {
   static Future<void> deleteAuth() async {
     await currentFirebaseUser!.delete();
   }
+
+  static Future<void> resetPassword(String email) async {
+    return firebaseAuth.sendPasswordResetEmail(email: email);
+  }
 }

--- a/lib/utils/navigation_utils.dart
+++ b/lib/utils/navigation_utils.dart
@@ -4,6 +4,7 @@ import 'package:disney_app/screen/create_account/create_account_screen.dart';
 import 'package:disney_app/screen/detail/detail_account_screen.dart';
 import 'package:disney_app/screen/detail/detail_screen.dart';
 import 'package:disney_app/screen/login/login_screen.dart';
+import 'package:disney_app/screen/login/password_reset_screen.dart';
 import 'package:disney_app/screen/post/post_screen.dart';
 import 'package:disney_app/screen/tab/tab_screen.dart';
 import 'package:flutter/material.dart';
@@ -80,6 +81,14 @@ class NavigationUtils {
     return Navigator.of(context).pushReplacement(
       MaterialPageRoute(
         builder: (context) => const LoginScreen(),
+      ),
+    );
+  }
+
+  static Future<void> passwordResetScreen(BuildContext context) {
+    return Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const PasswordResetScreen(),
       ),
     );
   }


### PR DESCRIPTION
## Issue

- close #19 

## 概要

- Firebaseのパスワードリセットを実装しました。
- メールアドレスが忘れた時のUIを実装しました。
- 送信のエラーハンドリングを追記しました。

## 追加したPackage
- なし

## Screenshot

![simulator_screenshot_C8989751-6476-4974-8B83-1E1A9D0C099B](https://github.com/iseruuuuu/disney_app/assets/67954894/73b2c687-8575-436a-a836-62f81986340d)


## 備考


