### PR TITLE
UIの微調整を行う

### DIFF
--- a/lib/core/component/app_attraction.dart
+++ b/lib/core/component/app_attraction.dart
@@ -27,13 +27,13 @@ class AppAttraction extends StatelessWidget {
       title: !isSelected
           ? Text(
               l10n.attraction,
-              style: AppTextStyle.appBoldBlue15TextStyle,
+              style: AppTextStyle.appBoldBlack16TextStyle,
             )
           : SizedBox(
               width: MediaQuery.of(context).size.width - 20,
               child: Text(
                 attractionName,
-                style: AppTextStyle.appBoldBlue15TextStyle,
+                style: AppTextStyle.appBoldBlack16TextStyle,
                 overflow: TextOverflow.ellipsis,
               ),
             ),

--- a/lib/core/component/app_disney_cell.dart
+++ b/lib/core/component/app_disney_cell.dart
@@ -149,7 +149,7 @@ class AppDisneyCell extends ConsumerWidget {
               width: MediaQuery.of(context).size.width - 80,
               child: Text(
                 '#${post.attractionName}',
-                style: AppTextStyle.appBoldBlue15TextStyle,
+                style: AppTextStyle.appBoldBlack16TextStyle,
                 overflow: TextOverflow.ellipsis,
               ),
             ),

--- a/lib/core/theme/app_text_style.dart
+++ b/lib/core/theme/app_text_style.dart
@@ -41,6 +41,12 @@ class AppTextStyle {
     fontSize: 15,
   );
 
+  static const appBoldBlack16TextStyle = TextStyle(
+    fontWeight: FontWeight.bold,
+    color: Colors.black,
+    fontSize: 16,
+  );
+
   static TextStyle appNormalGrey15TextStyle = TextStyle(
     fontWeight: FontWeight.normal,
     color: Colors.grey.shade600,
@@ -128,12 +134,6 @@ class AppTextStyle {
   static TextStyle appBold20GoogleFontsTextStyle = GoogleFonts.pattaya(
     fontWeight: FontWeight.bold,
     color: Colors.black,
-    fontSize: 20,
-  );
-
-  static const appBoldBlue20TextStyle = TextStyle(
-    fontWeight: FontWeight.bold,
-    color: Colors.blue,
     fontSize: 20,
   );
 

--- a/lib/screen/detail/detail_screen.dart
+++ b/lib/screen/detail/detail_screen.dart
@@ -128,7 +128,7 @@ class DetailScreen extends ConsumerWidget {
                       ),
                       child: Text(
                         post.attractionName,
-                        style: AppTextStyle.appBoldBlue20TextStyle,
+                        style: AppTextStyle.appBoldBlack20TextStyle,
                       ),
                     ),
                     Padding(

--- a/lib/screen/tab/tab_screen.dart
+++ b/lib/screen/tab/tab_screen.dart
@@ -12,10 +12,14 @@ class TabScreen extends ConsumerWidget {
     final controller = ref.watch(tabScreenViewModelProvider.notifier);
     return Scaffold(
       body: controller.pageList[state.selectedIndex],
-      bottomNavigationBar: DecoratedBox(
-        decoration: BoxDecoration(
+      bottomNavigationBar: Container(
+        width: MediaQuery.of(context).size.width,
+        decoration: const BoxDecoration(
           border: Border(
-            top: BorderSide(color: Colors.grey.shade400),
+            top: BorderSide(
+              width: 2,
+              color: AppColorStyle.appColor,
+            ),
           ),
         ),
         child: BottomNavigationBar(

--- a/lib/utils/function_utils.dart
+++ b/lib/utils/function_utils.dart
@@ -8,6 +8,7 @@ import 'package:disney_app/gen/gen.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:panara_dialogs/panara_dialogs.dart';
 
 class FunctionUtils {
   Future<dynamic> getImageFromGallery() async {
@@ -34,41 +35,18 @@ class FunctionUtils {
     required VoidCallback onTap,
   }) {
     final l10n = L10n.of(context)!;
-    return showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(
-            title,
-            style: AppTextStyle.appBoldBlack17TextStyle,
-            textAlign: TextAlign.center,
-          ),
-          content: Text(
-            content,
-            style: AppTextStyle.app500Black15TextStyle,
-            textAlign: TextAlign.center,
-          ),
-          actionsAlignment: MainAxisAlignment.spaceEvenly,
-          actions: [
-            TextButton(
-              child: Text(
-                l10n.dialog_cancel,
-                style: AppTextStyle.appBoldRed17TextStyle,
-              ),
-              onPressed: () => Navigator.pop(context),
-            ),
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                onTap();
-              },
-              child: Text(
-                l10n.dialog_ok,
-                style: AppTextStyle.appBoldBlue17TextStyle,
-              ),
-            ),
-          ],
-        );
+    return PanaraConfirmDialog.show(
+      context,
+      panaraDialogType: PanaraDialogType.error,
+      barrierDismissible: false,
+      title: title,
+      message: content,
+      confirmButtonText: l10n.dialog_ok,
+      cancelButtonText: l10n.dialog_cancel,
+      onTapCancel: () => Navigator.pop(context),
+      onTapConfirm: () {
+        Navigator.pop(context);
+        onTap();
       },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -877,6 +877,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  panara_dialogs:
+    dependency: "direct main"
+    description:
+      name: panara_dialogs
+      sha256: "0260305ffecc4c7e00655dd8824aa9ad4dc3fcb6ec9fcd97cd9fcf303db8205c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   image_picker: ^0.8.6+1
   intl: ^0.18.0
   loading_animation_widget: ^1.2.0+4
+  panara_dialogs: ^0.1.4
   path_provider: ^2.1.0
   screenshot: ^2.1.0
   share_plus: ^7.1.0


### PR DESCRIPTION
## Issue

- close #146 
- close #145 
- close #148 

## 概要

- アトラクション名の色を黒に戻してみる 
- タブと画面の境界をわかりやすくする
- ダイアログをおしゃれにしたい

## 追加したPackage

- panara_dialogs: ^0.1.4

## Screenshot

| Left align | Right align | 
|:-----------|------------:|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-31 at 13 35 27](https://github.com/iseruuuuu/disney_app/assets/67954894/7e0b11d0-b159-4ed1-9686-6d14616ff15e)   | ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-31 at 13 50 36](https://github.com/iseruuuuu/disney_app/assets/67954894/e5e60083-6463-4325-a619-64a0911343df) |  







## 備考

