### PR TITLE
ログアウトした後に別のアカウントでログインすると、修正画面が以前のアカウントになっている問題を修正しました。

### DIFF
--- a/lib/screen/edit/edit_view_model.dart
+++ b/lib/screen/edit/edit_view_model.dart
@@ -15,7 +15,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final editViewModelProvider =
-    StateNotifierProvider<EditScreenViewModel, ImageProvider>(
+    StateNotifierProvider.autoDispose<EditScreenViewModel, ImageProvider>(
   (ref) {
     final myAccount = AuthenticationService.myAccount!;
     return EditScreenViewModel(


### PR DESCRIPTION
## Issue

- close #150 

## 概要

- ログアウトした後に別のアカウントでログインすると、修正画面が以前のアカウントになっている問題を修正しました。
- autoDisposeをつけ忘れていた。

## 追加したPackage

- なし

## Screenshot


## 備考

