### PR TITLE
リリース前のUIの修正

### DIFF
--- a/lib/core/component/app_disney_cell.dart
+++ b/lib/core/component/app_disney_cell.dart
@@ -94,7 +94,7 @@ class AppDisneyCell extends ConsumerWidget {
               ),
               const Spacer(),
               Padding(
-                padding: const EdgeInsets.only(top: 5),
+                padding: const EdgeInsets.only(top: 5, right: 20),
                 child: account.isOfficial
                     ? Image.asset(
                         Assets.images.official.path,
@@ -161,7 +161,7 @@ class AppDisneyCell extends ConsumerWidget {
                           ),
                   ),
                 )
-              : SizedBox(),
+              : const SizedBox(),
           Padding(
             padding: const EdgeInsets.only(bottom: 5, left: 60),
             child: Row(

--- a/lib/core/component/app_disney_cell.dart
+++ b/lib/core/component/app_disney_cell.dart
@@ -124,41 +124,44 @@ class AppDisneyCell extends ConsumerWidget {
               ],
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 75),
-            child: Container(
-              width: MediaQuery.of(context).size.width - 100,
-              decoration: BoxDecoration(
-                color:
-                    !post.isSpoiler ? Colors.grey.shade200 : Colors.transparent,
-                borderRadius: BorderRadius.circular(5),
-              ),
-              child: !post.isSpoiler
-                  ? Padding(
-                      padding: const EdgeInsets.all(8),
-                      child: Text(
-                        post.content,
-                        style: AppTextStyle.appNormalBlack18TextStyle,
-                        overflow: TextOverflow.visible,
-                      ),
-                    )
-                  : Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          l10n.dialog_spoiler_cell_text,
-                          style: AppTextStyle.appBoldRed15TextStyle,
-                          overflow: TextOverflow.visible,
-                        ),
-                        const Icon(
-                          Icons.arrow_forward,
-                          color: Colors.red,
-                          size: 30,
-                        ),
-                      ],
+          post.content.isNotEmpty
+              ? Padding(
+                  padding: const EdgeInsets.only(left: 75),
+                  child: Container(
+                    width: MediaQuery.of(context).size.width - 100,
+                    decoration: BoxDecoration(
+                      color: !post.isSpoiler
+                          ? Colors.grey.shade200
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(5),
                     ),
-            ),
-          ),
+                    child: !post.isSpoiler
+                        ? Padding(
+                            padding: const EdgeInsets.all(8),
+                            child: Text(
+                              post.content,
+                              style: AppTextStyle.appNormalBlack18TextStyle,
+                              overflow: TextOverflow.visible,
+                            ),
+                          )
+                        : Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                l10n.dialog_spoiler_cell_text,
+                                style: AppTextStyle.appBoldRed15TextStyle,
+                                overflow: TextOverflow.visible,
+                              ),
+                              const Icon(
+                                Icons.arrow_forward,
+                                color: Colors.red,
+                                size: 30,
+                              ),
+                            ],
+                          ),
+                  ),
+                )
+              : SizedBox(),
           Padding(
             padding: const EdgeInsets.only(bottom: 5, left: 60),
             child: Row(

--- a/lib/core/component/app_disney_cell.dart
+++ b/lib/core/component/app_disney_cell.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:disney_app/core/component/component.dart';
 import 'package:disney_app/core/constants/account.dart';
 import 'package:disney_app/core/model/account.dart';
 import 'package:disney_app/core/model/post.dart';
@@ -78,6 +79,11 @@ class AppDisneyCell extends ConsumerWidget {
                                 overflow: TextOverflow.ellipsis,
                                 style: AppTextStyle.appBoldBlack18TextStyle,
                               ),
+                              Text(
+                                post.attractionName,
+                                style: AppTextStyle.appBoldGrey16TextStyle,
+                                overflow: TextOverflow.ellipsis,
+                              ),
                             ],
                           ),
                         ),
@@ -106,25 +112,35 @@ class AppDisneyCell extends ConsumerWidget {
             ],
           ),
           Padding(
-            padding: const EdgeInsets.only(left: 75),
-            child: SizedBox(
-              width: MediaQuery.of(context).size.width - 80,
-              child: Text(
-                '#${post.attractionName}',
-                style: AppTextStyle.appBoldBlack16TextStyle,
-                overflow: TextOverflow.ellipsis,
-              ),
+            padding: const EdgeInsets.only(left: 75, top: 5, bottom: 10),
+            child: Row(
+              children: [
+                AppCellRating(rank: post.rank),
+                const SizedBox(width: 10),
+                Text(
+                  '${post.rank}点',
+                  style: AppTextStyle.appBoldBlack17TextStyle,
+                ),
+              ],
             ),
           ),
           Padding(
-            padding: const EdgeInsets.only(top: 15, left: 75),
-            child: SizedBox(
+            padding: const EdgeInsets.only(left: 75),
+            child: Container(
               width: MediaQuery.of(context).size.width - 100,
+              decoration: BoxDecoration(
+                color:
+                    !post.isSpoiler ? Colors.grey.shade200 : Colors.transparent,
+                borderRadius: BorderRadius.circular(5),
+              ),
               child: !post.isSpoiler
-                  ? Text(
-                      post.content,
-                      style: AppTextStyle.appNormalBlack18TextStyle,
-                      overflow: TextOverflow.visible,
+                  ? Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Text(
+                        post.content,
+                        style: AppTextStyle.appNormalBlack18TextStyle,
+                        overflow: TextOverflow.visible,
+                      ),
                     )
                   : Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -137,14 +153,14 @@ class AppDisneyCell extends ConsumerWidget {
                         const Icon(
                           Icons.arrow_forward,
                           color: Colors.red,
-                          size: 40,
+                          size: 30,
                         ),
                       ],
                     ),
             ),
           ),
           Padding(
-            padding: const EdgeInsets.only(top: 5, bottom: 5, left: 60),
+            padding: const EdgeInsets.only(bottom: 5, left: 60),
             child: Row(
               children: [
                 IconButton(
@@ -169,7 +185,7 @@ class AppDisneyCell extends ConsumerWidget {
                           updatePost,
                         );
                   },
-                  iconSize: 25,
+                  iconSize: 23,
                   icon: const Icon(
                     CupertinoIcons.heart,
                     color: Colors.pinkAccent,
@@ -177,7 +193,7 @@ class AppDisneyCell extends ConsumerWidget {
                 ),
                 Text(
                   post.heart.toString(),
-                  style: AppTextStyle.appNormalBlack20TextStyle,
+                  style: AppTextStyle.appNormalBlack18TextStyle,
                 ),
                 const Spacer(),
                 Padding(

--- a/lib/core/component/app_header.dart
+++ b/lib/core/component/app_header.dart
@@ -72,6 +72,20 @@ class AppHeader extends StatelessWidget {
                       ),
                       Row(
                         children: [
+                          account.isOfficial
+                              ? Image.asset(
+                                  Assets.images.official.path,
+                                  fit: BoxFit.fill,
+                                  width: 30,
+                                )
+                              : (account.id == MasterAccount.masterAccount)
+                                  ? Image.asset(
+                                      Assets.images.dev.path,
+                                      fit: BoxFit.fill,
+                                      width: 30,
+                                    )
+                                  : const SizedBox.shrink(),
+                          const SizedBox(width: 5),
                           IconButton(
                             onPressed: isHasTwitter ? onTapTwitter : null,
                             icon: Icon(
@@ -93,26 +107,6 @@ class AppHeader extends StatelessWidget {
                   ),
                 ),
                 const Spacer(),
-                Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 45),
-                      child: account.isOfficial
-                          ? Image.asset(
-                              Assets.images.official.path,
-                              fit: BoxFit.fill,
-                              width: 40,
-                            )
-                          : (account.id == MasterAccount.masterAccount)
-                              ? Image.asset(
-                                  Assets.images.dev.path,
-                                  fit: BoxFit.fill,
-                                  width: 30,
-                                )
-                              : const SizedBox.shrink(),
-                    ),
-                  ],
-                ),
                 const SizedBox(width: 10),
               ],
             ),

--- a/lib/core/component/app_rating.dart
+++ b/lib/core/component/app_rating.dart
@@ -37,3 +37,24 @@ class AppRating extends StatelessWidget {
           );
   }
 }
+
+class AppCellRating extends StatelessWidget {
+  const AppCellRating({
+    super.key,
+    required this.rank,
+  });
+
+  final double rank;
+
+  @override
+  Widget build(BuildContext context) {
+    return RatingBarIndicator(
+      rating: rank,
+      itemSize: 25,
+      itemBuilder: (context, _) => const Icon(
+        Icons.star,
+        color: Colors.amber,
+      ),
+    );
+  }
+}

--- a/lib/core/theme/app_text_style.dart
+++ b/lib/core/theme/app_text_style.dart
@@ -41,6 +41,12 @@ class AppTextStyle {
     fontSize: 15,
   );
 
+  static const appNormalBlack16TextStyle = TextStyle(
+    fontWeight: FontWeight.normal,
+    color: Colors.black,
+    fontSize: 16,
+  );
+
   static const appBoldBlack16TextStyle = TextStyle(
     fontWeight: FontWeight.bold,
     color: Colors.black,

--- a/lib/core/theme/app_text_style.dart
+++ b/lib/core/theme/app_text_style.dart
@@ -89,6 +89,12 @@ class AppTextStyle {
     fontSize: 17,
   );
 
+  static const appBoldGrey18TextStyle = TextStyle(
+    fontWeight: FontWeight.bold,
+    color: Colors.grey,
+    fontSize: 18,
+  );
+
   static const appNormalBlack18TextStyle = TextStyle(
     fontWeight: FontWeight.normal,
     color: Colors.black,

--- a/lib/screen/detail/detail_screen.dart
+++ b/lib/screen/detail/detail_screen.dart
@@ -151,7 +151,7 @@ class DetailScreen extends ConsumerWidget {
                     ),
                     Padding(
                       padding: const EdgeInsets.symmetric(
-                        horizontal: 20,
+                        horizontal: 15,
                         vertical: 5,
                       ),
                       child: Row(
@@ -159,7 +159,7 @@ class DetailScreen extends ConsumerWidget {
                           const Icon(
                             CupertinoIcons.heart_fill,
                             color: Colors.pinkAccent,
-                            size: 30,
+                            size: 25,
                           ),
                           const SizedBox(width: 15),
                           RichText(
@@ -167,11 +167,11 @@ class DetailScreen extends ConsumerWidget {
                               children: <TextSpan>[
                                 TextSpan(
                                   text: '${post.heart}',
-                                  style: AppTextStyle.appBoldBlack18TextStyle,
+                                  style: AppTextStyle.appBoldBlack16TextStyle,
                                 ),
                                 const TextSpan(
                                   text: ' 件のいいね',
-                                  style: AppTextStyle.appNormalBlack18TextStyle,
+                                  style: AppTextStyle.appNormalBlack16TextStyle,
                                 ),
                               ],
                             ),
@@ -185,7 +185,7 @@ class DetailScreen extends ConsumerWidget {
                         SizedBox(
                           width: MediaQuery.of(context).size.width,
                           child: Padding(
-                            padding: const EdgeInsets.all(20),
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
                             child: Row(
                               children: [
                                 Text(

--- a/lib/screen/detail/detail_screen.dart
+++ b/lib/screen/detail/detail_screen.dart
@@ -59,7 +59,7 @@ class DetailScreen extends ConsumerWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             SizedBox(
-                              width: MediaQuery.of(context).size.width / 1.5,
+                              width: MediaQuery.of(context).size.width / 1.8,
                               child: Padding(
                                 padding: const EdgeInsets.only(right: 10),
                                 child: Text(
@@ -89,14 +89,14 @@ class DetailScreen extends ConsumerWidget {
                             ? Image.asset(
                                 Assets.images.official.path,
                                 fit: BoxFit.fill,
-                                width: 45,
+                                width: 35,
                               )
                             : (post.postAccountId ==
                                     MasterAccount.masterAccount)
                                 ? Image.asset(
                                     Assets.images.dev.path,
                                     fit: BoxFit.fill,
-                                    width: 45,
+                                    width: 35,
                                   )
                                 : const SizedBox.shrink(),
                         const SizedBox(width: 10),

--- a/lib/screen/edit/edit_sns_screen.dart
+++ b/lib/screen/edit/edit_sns_screen.dart
@@ -1,3 +1,4 @@
+import 'package:disney_app/core/component/app_loading.dart';
 import 'package:disney_app/core/component/app_text_button.dart';
 import 'package:disney_app/core/component/app_text_field.dart';
 import 'package:disney_app/core/theme/theme.dart';
@@ -7,7 +8,6 @@ import 'package:disney_app/provider/loading_provider.dart';
 import 'package:disney_app/screen/edit/edit_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:loading_animation_widget/loading_animation_widget.dart';
 
 class EditSNSScreen extends ConsumerWidget {
   const EditSNSScreen({super.key});
@@ -45,59 +45,55 @@ class EditSNSScreen extends ConsumerWidget {
         body: SingleChildScrollView(
           child: Stack(
             children: [
-              SizedBox(
-                height: MediaQuery.of(context).size.height,
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                      child: AppTextField(
-                        controller: controller.twitterController,
-                        hintText: l10n.twitter_hint_text,
-                        maxLines: 1,
+              AbsorbPointer(
+                absorbing: loading,
+                child: SizedBox(
+                  height: MediaQuery.of(context).size.height,
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 10),
+                        child: AppTextField(
+                          controller: controller.twitterController,
+                          hintText: l10n.twitter_hint_text,
+                          maxLines: 1,
+                        ),
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                      child: AppTextField(
-                        controller: controller.instagramController,
-                        hintText: l10n.instagram_hint_text,
-                        maxLines: 1,
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 10),
+                        child: AppTextField(
+                          controller: controller.instagramController,
+                          hintText: l10n.instagram_hint_text,
+                          maxLines: 1,
+                        ),
                       ),
-                    ),
-                    Text(
-                      l10n.sns_title,
-                      style: AppTextStyle.appBold20GoogleFontsTextStyle,
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 20,
-                        vertical: 10,
+                      Text(
+                        l10n.sns_title,
+                        style: AppTextStyle.appBold20GoogleFontsTextStyle,
                       ),
-                      child: Text(
-                        l10n.sns_description,
-                        style: AppTextStyle.app500Black15TextStyle,
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 20,
+                          vertical: 10,
+                        ),
+                        child: Text(
+                          l10n.sns_description,
+                          style: AppTextStyle.app500Black15TextStyle,
+                        ),
                       ),
-                    ),
-                    const Spacer(),
-                    AppTextButton(
-                      onPressed: () =>
-                          ref.read(launchUrlProvider).reportSNS(context),
-                      title: l10n.sns_report,
-                      color: Colors.red,
-                    ),
-                    const Spacer(flex: 2),
-                  ],
+                      const Spacer(),
+                      AppTextButton(
+                        onPressed: () =>
+                            ref.read(launchUrlProvider).reportSNS(context),
+                        title: l10n.sns_report,
+                        color: Colors.red,
+                      ),
+                      const Spacer(flex: 2),
+                    ],
+                  ),
                 ),
               ),
-              loading
-                  ? Center(
-                      child: LoadingAnimationWidget.dotsTriangle(
-                        color: AppColorStyle.appColor,
-                        size: 50,
-                      ),
-                    )
-                  : const SizedBox(),
+              if (loading) const AppLoading(),
             ],
           ),
         ),

--- a/lib/screen/post/post_screen.dart
+++ b/lib/screen/post/post_screen.dart
@@ -25,12 +25,16 @@ class PostScreen extends ConsumerWidget {
           elevation: 0,
           actions: [
             TextButton(
-              onPressed: () => ref
-                  .read(postScreenViewModelProvider.notifier)
-                  .post(context, ref),
+              onPressed: (state.attractionName.isNotEmpty)
+                  ? () => ref
+                      .read(postScreenViewModelProvider.notifier)
+                      .post(context, ref)
+                  : null,
               child: Text(
                 l10n.post,
-                style: AppTextStyle.appBoldBlue18TextStyle,
+                style: (state.attractionName.isNotEmpty)
+                    ? AppTextStyle.appBoldBlue18TextStyle
+                    : AppTextStyle.appBoldGrey18TextStyle,
               ),
             ),
           ],

--- a/lib/screen/post/post_screen_view_model.dart
+++ b/lib/screen/post/post_screen_view_model.dart
@@ -65,7 +65,7 @@ class PostScreenViewModel extends StateNotifier<PostScreenState> {
   Future<void> post(BuildContext context, WidgetRef ref) async {
     final l10n = L10n.of(context)!;
     loading.isLoading = true;
-    if (controller.text.isNotEmpty && state.attractionName != '') {
+    if (state.attractionName != '') {
       final newPost = Post(
         content: controller.text,
         postAccountId: AuthenticationService.myAccount!.id,


### PR DESCRIPTION
## Issue

- close #173 
- close #174 
- close #175 
- close #176 
- close #178
- close #179

## 概要

- いいねのテキストとアイコンを小さくする
- SNS編集のローディングを修正する 
- 投稿が空だったら、スナックバーの文言を変える
- Appdisneycellのテキストスタイルを修正する
- 投稿詳細画面のUIを整える
- 公式マークの位置がおかしくなっている不具合を治す

## 追加したPackage

- なし

## Screenshot

| Left align | Right align | Center align |
|:-----------|------------:|:------------:|
|  ![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-15 at 13 53 55](https://github.com/iseruuuuu/disney_app/assets/67954894/a032e901-4adb-49e1-b87d-2cae5f6c2ada)  | ![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-15 at 14 01 18](https://github.com/iseruuuuu/disney_app/assets/67954894/43bb9672-aac4-42d5-8023-6b611770d735) |  ![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-15 at 14 07 53](https://github.com/iseruuuuu/disney_app/assets/67954894/685875c5-e4c5-49a3-b549-02f6700af918)  |


# 公式マークの修正


| Left align | Right align | Center align |
|:-----------|------------:|:------------:|
|  ![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-15 at 14 29 46](https://github.com/iseruuuuu/disney_app/assets/67954894/9a34629e-b9a4-4e5d-8aa2-86dd6af16e7c) | ![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-15 at 14 29 48](https://github.com/iseruuuuu/disney_app/assets/67954894/fee097b3-166a-4bfd-b00d-f27c61d237bf)  |  ![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-15 at 14 29 52](https://github.com/iseruuuuu/disney_app/assets/67954894/d512e6b2-aefc-45f8-859c-d2a8c0ceddc1)  |







## 動画

https://github.com/iseruuuuu/disney_app/assets/67954894/42a9b755-13d2-4d7d-91a0-3837499f6b8c






## 備考

